### PR TITLE
(#1) feat: add strategy command for multi-agent repo analysis

### DIFF
--- a/.claude/commands/strategy.md
+++ b/.claude/commands/strategy.md
@@ -366,6 +366,7 @@ echo "Start with: cat ./strategy/strategy.md"
 5. For sparse repos with few files, focus on what exists rather than leaving sections empty
 6. Run agents in parallel where possible for efficiency
 7. Always create `./strategy/` directory before writing any files
+8. **All analysis reports and outputs must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
 
 ## References
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /strategy/
+.omc/
+.claude/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 seunggabi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ cd .claude/commands
 curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/commit-push-pr.md
 curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/done.md
 curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/sync.md
+curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/strategy.md
 curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/cleanup.md
 curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/status.md
 curl -O https://raw.githubusercontent.com/seunggabi/claude-command/main/release.md

--- a/changelog.md
+++ b/changelog.md
@@ -103,3 +103,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 4. Order: Features, Fixes, Refactoring, Docs, Chores
 5. Use [Keep a Changelog](https://keepachangelog.com) format
 6. Date format: YYYY-MM-DD
+7. **All outputs and summaries must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)

--- a/cleanup.md
+++ b/cleanup.md
@@ -57,3 +57,4 @@ git branch -a
 3. Run `git fetch --prune` first to sync remote state
 4. Use `-d` (safe delete) not `-D` (force delete) for local branches
 5. Protected branches on GitHub won't be deleted remotely
+6. **All outputs and confirmations must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)

--- a/commit-push-pr.md
+++ b/commit-push-pr.md
@@ -103,6 +103,7 @@ gh pr create --title "(#{issue_number}) {type}: {PR title}" --body "Closes #{iss
 3. Alias should be a short English kebab-case identifier
 4. If not on main branch, skip issue creation and proceed with commit/push/PR on current branch
 5. Use present tense for commit messages ("add" not "added")
+6. **All outputs, issue bodies, and PR descriptions must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
 
 ## References
 - [Semantic Commit Messages](https://gist.github.com/joshbuchea/6f47e86d2510bce28f8e7f42ae84c716)

--- a/done.md
+++ b/done.md
@@ -50,3 +50,4 @@ git branch -d {branch_name}
 3. Resolve merge conflicts first if any
 4. If PR body contains `Closes #123` format, issue will be auto-closed
 5. Manually close issue only if auto-close didn't work
+6. **All outputs and status messages must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)

--- a/release.md
+++ b/release.md
@@ -72,3 +72,4 @@ gh release create v{VERSION} --title "v{VERSION}" --notes "## What's Changed
 4. Include meaningful release notes
 5. Link to full changelog for details
 6. Consider pre-release tags (v1.0.0-beta.1) for testing
+7. **All release notes and outputs must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)

--- a/status.md
+++ b/status.md
@@ -67,3 +67,4 @@ Display results in a clean, organized format:
 2. Highlight items that need attention
 3. Show age of issues/PRs if stale (>7 days)
 4. Indicate CI status for open PRs
+5. **All outputs and summaries must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)

--- a/sync.md
+++ b/sync.md
@@ -57,3 +57,4 @@ git push --force-with-lease
 2. If on main branch, just pull instead of rebase
 3. Resolve conflicts carefully before continuing rebase
 4. Stash is only created if there are uncommitted changes
+5. **All outputs and status messages must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)


### PR DESCRIPTION
## Summary
- Add `/strategy` command for comprehensive multi-agent repository analysis
- 7 specialized agents: Architect, Product, Security, Ops, Performance, Quality, DX
- Outputs 12 structured reports to `./strategy/` directory

## Changes
- `.claude/commands/strategy.md` - New command file (915 lines)
- `README.md` - Documentation and installation instructions

## Features
### Phase 0 - Repo Intake
- Print repository context (git status, branch, remotes)
- Generate directory tree (depth 4)
- Identify and read key files

### Phase 1 - Multi-Agent Analysis
| Agent | Focus Area |
|-------|------------|
| A - Architect | System structure, modules, tech debt |
| B - Product | Value prop, use cases, documentation |
| C - Security | Secrets, vulnerabilities, OWASP Top 10 |
| D - Ops | Deployment, observability, failure modes |
| E - Performance | Hot paths, N+1 queries, caching |
| F - Quality | Testing, CI/CD, release process |
| G - DX | Setup friction, tooling, onboarding |

### Phase 2 - Synthesis
- `strategy.md` - Main strategy report
- `backlog.md` - Prioritized backlog with Impact/Effort scoring
- `roadmap.md` - 2-week and 6-week execution plans

## Test Plan
- [ ] Run `/strategy` on a test repository
- [ ] Verify all 12 output files are generated
- [ ] Check evidence citations in reports

Closes #1