### PR TITLE
(#25) refactor: enforce English-only output in all commands

### DIFF
--- a/.claude/commands/changelog.md
+++ b/.claude/commands/changelog.md
@@ -117,4 +117,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 4. Order: Features, Fixes, Refactoring, Docs, Chores
 5. Use [Keep a Changelog](https://keepachangelog.com) format
 6. Date format: YYYY-MM-DD
-7. **All outputs and summaries must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+7. **All outputs and summaries must be written in English**

--- a/.claude/commands/cleanup.md
+++ b/.claude/commands/cleanup.md
@@ -63,4 +63,4 @@ git branch -a
 3. Run `git fetch --prune` first to sync remote state
 4. Use `-d` (safe delete) not `-D` (force delete) for local branches
 5. Protected branches on GitHub won't be deleted remotely
-6. **All outputs and confirmations must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+6. **All outputs and confirmations must be written in English**

--- a/.claude/commands/commit-push-pr.md
+++ b/.claude/commands/commit-push-pr.md
@@ -116,7 +116,7 @@ gh pr create --title "(#{issue_number}) {type}: {PR title}" --body "Closes #{iss
 3. Alias should be a short English kebab-case identifier
 4. If not on main branch, skip issue creation and proceed with commit/push/PR on current branch
 5. Use present tense for commit messages ("add" not "added")
-6. **All outputs, issue bodies, and PR descriptions must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+6. **All outputs, issue bodies, and PR descriptions must be written in English**
 
 ## References
 

--- a/.claude/commands/cppdt.md
+++ b/.claude/commands/cppdt.md
@@ -104,7 +104,7 @@ Phase N: Attempt 1
 3. If PR is not mergeable (CI failing, review needed), retry with appropriate fix
 4. Follow all conventions from individual commands (commit format, branch naming, etc.)
 5. The `/tag` argument can be passed to this command to override auto-detection (e.g., `/commit-push-pr_done_tag major`)
-6. **All outputs must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+6. **All outputs must be written in English**
 
 ## Error Handling
 

--- a/.claude/commands/done.md
+++ b/.claude/commands/done.md
@@ -56,4 +56,4 @@ git branch -d {branch_name}
 3. Resolve merge conflicts first if any
 4. If PR body contains `Closes #123` format, issue will be auto-closed
 5. Manually close issue only if auto-close didn't work
-6. **All outputs and status messages must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+6. **All outputs and status messages must be written in English**

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -80,4 +80,4 @@ gh release create v{VERSION} --title "v{VERSION}" --notes "## What's Changed
 4. Include meaningful release notes
 5. Link to full changelog for details
 6. Consider pre-release tags (v1.0.0-beta.1) for testing
-7. **All release notes and outputs must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+7. **All release notes and outputs must be written in English**

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -74,4 +74,4 @@ Display results in a clean, organized format:
 2. Highlight items that need attention
 3. Show age of issues/PRs if stale (>7 days)
 4. Indicate CI status for open PRs
-5. **All outputs and summaries must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+5. **All outputs and summaries must be written in English**

--- a/.claude/commands/strategy.md
+++ b/.claude/commands/strategy.md
@@ -373,7 +373,7 @@ echo "Start with: cat ./strategy/strategy.md"
 5. For sparse repos with few files, focus on what exists rather than leaving sections empty
 6. Run agents in parallel where possible for efficiency
 7. Always create `./strategy/` directory before writing any files
-8. **All analysis reports and outputs must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+8. **All analysis reports and outputs must be written in English**
 
 ## References
 

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -65,4 +65,4 @@ git push --force-with-lease
 2. If on main branch, just pull instead of rebase
 3. Resolve conflicts carefully before continuing rebase
 4. Stash is only created if there are uncommitted changes
-5. **All outputs and status messages must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+5. **All outputs and status messages must be written in English**

--- a/.claude/commands/tag.md
+++ b/.claude/commands/tag.md
@@ -136,7 +136,7 @@ gh release create {NEW_TAG} --title "{NEW_TAG}" --notes "{release_notes}"
 5. Merge commits (e.g., `Merge pull request #N`) should be excluded from changelog entries
 6. Release notes should group commits cleanly with no empty sections
 7. Include the full changelog comparison link at the bottom
-8. **All release notes and outputs must be written in the user's configured language** (check CLAUDE.md or system settings for language preference)
+8. **All release notes and outputs must be written in English**
 
 ## Examples
 


### PR DESCRIPTION
Closes #25

## Changes
- Replace configurable language preference with fixed English output rule in all 10 command files
- Remove `(check CLAUDE.md or system settings for language preference)` references
- Set English as the mandatory output language for all commands