### PR TITLE
(#28) feat: add automatic skills installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The following tools must be installed:
 | [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) | -           | `claude --version` | [Official Docs](https://docs.anthropic.com/en/docs/claude-code) |
 | [Git](https://git-scm.com/)                                       | 2.0+        | `git --version`    | `brew install git`                                              |
 | [GitHub CLI](https://cli.github.com/)                             | 2.0+        | `gh --version`     | `brew install gh`                                               |
+| [Node.js](https://nodejs.org/) (for skills)                       | 16.0+       | `node --version`   | `brew install node`                                             |
 
 ### GitHub CLI Authentication
 
@@ -38,6 +39,7 @@ git clone https://github.com/seunggabi/claude-command.git /tmp/claude-command &&
 
 This installs:
 - Commands → `~/.claude/commands/`
+- Skills → Claude Code Skills (obra/superpowers, blader/humanizer, nextlevelbuilder/ui-ux-pro-max-skill, vercel-labs/skills)
 - Settings → `~/.claude/settings.json`
 - Rules → `~/.claude/CLAUDE.md`
 
@@ -51,6 +53,7 @@ git clone https://github.com/seunggabi/claude-command.git /tmp/claude-command &&
 
 This installs:
 - Commands → `.claude/commands/`
+- Skills → Claude Code Skills (obra/superpowers, blader/humanizer, nextlevelbuilder/ui-ux-pro-max-skill, vercel-labs/skills)
 - Settings → `.claude/settings.json`
 - Rules → `.claude/CLAUDE.md`
 
@@ -64,6 +67,19 @@ Re-run the install command. The installer is idempotent — it replaces the mana
 # Remove rules block (preserves other content)
 ./install.sh --uninstall
 ```
+
+### Installed Skills
+
+The installer automatically adds the following Claude Code skills:
+
+| Skill                                | Description                                      |
+| ------------------------------------ | ------------------------------------------------ |
+| `obra/superpowers`                   | Enhanced capabilities and workflow automation    |
+| `blader/humanizer`                   | Natural language improvements                    |
+| `nextlevelbuilder/ui-ux-pro-max-skill` | Advanced UI/UX development                      |
+| `vercel-labs/skills`                 | Vercel's official skill collection               |
+
+**Note:** If `npx` is not available, the installer will skip skills and display manual installation instructions.
 
 ### How It Works
 

--- a/install.sh
+++ b/install.sh
@@ -183,6 +183,44 @@ install_commands() {
   echo "  Installed to $target_commands_dir"
 }
 
+# --- Helper: Install skills ---
+install_skills() {
+  echo "Installing skills..."
+
+  # Check if npx is available
+  if ! command -v npx &> /dev/null; then
+    echo "  Warning: npx not found. Skipping skills installation."
+    echo "  To install skills manually, run:"
+    echo "    npx skills add obra/superpowers"
+    echo "    npx skills add blader/humanizer"
+    echo "    npx skills add nextlevelbuilder/ui-ux-pro-max-skill"
+    echo "    npx skills add vercel-labs/skills"
+    return 0
+  fi
+
+  local skills=(
+    "obra/superpowers"
+    "blader/humanizer"
+    "nextlevelbuilder/ui-ux-pro-max-skill"
+    "vercel-labs/skills"
+  )
+
+  local installed=0
+  local failed=0
+
+  for skill in "${skills[@]}"; do
+    echo "  Installing $skill..."
+    if npx skills add "$skill" 2>&1 | grep -q "Added\|already installed"; then
+      installed=$((installed + 1))
+    else
+      echo "    Warning: Failed to install $skill"
+      failed=$((failed + 1))
+    fi
+  done
+
+  echo "  Skills installation complete: $installed installed, $failed failed"
+}
+
 # --- Uninstall mode ---
 if [[ "$UNINSTALL" == true ]]; then
   remove_block "$TARGET_FILE"
@@ -205,6 +243,9 @@ TARGET_SETTINGS="${TARGET_DIR}/settings.json"
 
 # Install commands
 install_commands "$TARGET_COMMANDS_DIR"
+
+# Install skills
+install_skills
 
 # Install settings.json (merge, not overwrite)
 if [[ -f "$SOURCE_SETTINGS" ]]; then
@@ -238,6 +279,7 @@ echo "Installed CLAUDE-COMMAND rules to $TARGET_FILE"
 echo ""
 echo "Done! Installed:"
 echo "  - Commands   → $TARGET_COMMANDS_DIR"
+echo "  - Skills     → Claude Code Skills"
 echo "  - Settings   → $TARGET_SETTINGS"
 echo "  - Rules      → $TARGET_FILE"
 echo ""


### PR DESCRIPTION
## Summary
Add automatic installation of Claude Code skills to the installer.

## Changes
- Add `install_skills()` function to install.sh that installs 4 Claude Code skills
- Install skills automatically during installation process
- Update README.md with Node.js prerequisite (16.0+)
- Add "Installed Skills" section to README with descriptions

## Installed Skills
- `obra/superpowers` - Enhanced capabilities and workflow automation
- `blader/humanizer` - Natural language improvements
- `nextlevelbuilder/ui-ux-pro-max-skill` - Advanced UI/UX development
- `vercel-labs/skills` - Vercel's official skill collection

## Implementation Details
- Check for npx availability before attempting installation
- Auto-install each skill with error handling
- Provide manual installation instructions if npx is not available
- Display installation summary (installed/failed count)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)