### PR TITLE
(#30) feat: add model switching script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Custom commands for Claude Code CLI.
 
+```shell
+./model.sh sonnet
+```
+
+```shell
+./model.sh haiku
+```
+
 ## Prerequisites
 
 The following tools must be installed:

--- a/model.sh
+++ b/model.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+SETTINGS="$HOME/.claude/settings.json"
+
+HAIKU=${HAIKU:-"claude-haiku-3-5-20251001"}
+SONNET=${SONNET:-"claude-sonnet-4-5-20250929"}
+OPUS=${OPUS:-"claude-opus-4-6"}
+
+set_model() {
+  jq --arg m "$1" '.model = $m' "$SETTINGS" > /tmp/s.tmp && mv /tmp/s.tmp "$SETTINGS"
+  echo "✅ $1"
+}
+
+case "$1" in
+  sonnet) set_model "$SONNET" ;;
+  haiku)  set_model "$HAIKU" ;;
+  opus)  set_model "$OPUS" ;;
+  *)      echo "Usage: $0 [sonnet|haiku|opus]" ;;
+esac


### PR DESCRIPTION
## Summary
- Add `model.sh` script to switch Claude Code model (sonnet/haiku/opus) via `~/.claude/settings.json`
- Add usage examples to README.md

Closes #30

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>