### PR TITLE
feat: update Sonnet model to 4.6

### DIFF
--- a/model.sh
+++ b/model.sh
@@ -3,7 +3,7 @@
 SETTINGS="$HOME/.claude/settings.json"
 
 HAIKU=${HAIKU:-"claude-haiku-3-5-20251001"}
-SONNET=${SONNET:-"claude-sonnet-4-5-20250929"}
+SONNET=${SONNET:-"claude-sonnet-4-6"}
 OPUS=${OPUS:-"claude-opus-4-6"}
 
 set_model() {


### PR DESCRIPTION
Update the default Sonnet model from claude-sonnet-4-5-20250929 to claude-sonnet-4-6 in model.sh script.

## Changes
- Update SONNET variable to use claude-sonnet-4-6

## Rationale
- Use the latest Sonnet 4.6 model for improved performance and capabilities

Closes #32